### PR TITLE
Fix array out-of-bounds in Doctor.tsx and missing new in ReferenceError

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -704,7 +704,7 @@ export function hasCommand(commandName: string, commands: Command[]): boolean {
 export function getCommand(commandName: string, commands: Command[]): Command {
   const command = findCommand(commandName, commands)
   if (!command) {
-    throw ReferenceError(
+    throw new ReferenceError(
       `Command ${commandName} not found. Available commands: ${commands
         .map(_ => {
           const name = getCommandName(_)

--- a/src/screens/Doctor.tsx
+++ b/src/screens/Doctor.tsx
@@ -324,7 +324,7 @@ export function Doctor(t0) {
   }
   let t19;
   if ($[32] !== diagnostic.recommendation) {
-    t19 = diagnostic.recommendation && <><Text /><Text color="warning">Recommendation: {diagnostic.recommendation.split("\n")[0]}</Text><Text dimColor={true}>{diagnostic.recommendation.split("\n")[1]}</Text></>;
+    t19 = diagnostic.recommendation && <><Text /><Text color="warning">Recommendation: {diagnostic.recommendation.split("\n")[0]}</Text><Text dimColor={true}>{diagnostic.recommendation.split("\n")[1] ?? ""}</Text></>;
     $[32] = diagnostic.recommendation;
     $[33] = t19;
   } else {

--- a/src/utils/claudeInChrome/setup.ts
+++ b/src/utils/claudeInChrome/setup.ts
@@ -193,7 +193,7 @@ export async function installChromeNativeHostManifest(
 ): Promise<void> {
   const manifestDirs = getNativeMessagingHostsDirs()
   if (manifestDirs.length === 0) {
-    throw Error('Claude in Chrome Native Host not supported on this platform')
+    throw new Error('Claude in Chrome Native Host not supported on this platform')
   }
 
   const manifest = {


### PR DESCRIPTION
## Summary

- **`src/screens/Doctor.tsx:327`**: `diagnostic.recommendation.split("\n")[1]` can be `undefined` when recommendation has no newline. Added `?? ""` fallback.
- **`src/commands.ts:707`**: `throw ReferenceError()` → `throw new ReferenceError()` — missing `new` keyword

🤖 Generated with [Claude Code](https://claude.com/claude-code)